### PR TITLE
Correct last frame reflection issue

### DIFF
--- a/src/cprotocol.cpp
+++ b/src/cprotocol.cpp
@@ -184,6 +184,10 @@ void CProtocol::OnDvLastFramePacketIn(std::unique_ptr<CDvLastFramePacket> &Frame
 		stream->Unlock();
 
 		// Don't close yet, this stops the last packet relfection bug that was fixed in upstream by the same change.
+		// Don't close the stream yet but rely on CheckStreamsTimeout
+        	// mechanism, so the stream will be closed after the queues have
+        	// been sinked out. This avoid last packets to be send back
+        	// to transmitting client (master)
 		
 	}
 	// else

--- a/src/cprotocol.cpp
+++ b/src/cprotocol.cpp
@@ -183,8 +183,8 @@ void CProtocol::OnDvLastFramePacketIn(std::unique_ptr<CDvLastFramePacket> &Frame
 		stream->Push(std::move(Frame));
 		stream->Unlock();
 
-		// and close the stream
-		g_Reflector.CloseStream(stream);
+		// Don't close yet, this stops the last packet relfection bug that was fixed in upstream by the same change.
+		
 	}
 	// else
 	// {


### PR DESCRIPTION
There's a bug in this version that reflects the last frame to the sender, this is the change from upstream that corrects the issue.