### PR TITLE
Fix multiple connections from the same IP [Issue 2]

### DIFF
--- a/src/cclient.cpp
+++ b/src/cclient.cpp
@@ -77,6 +77,7 @@ bool CClient::operator ==(const CClient &client) const
 {
 	return ((client.m_Callsign == m_Callsign) &&
 			(client.m_Ip == m_Ip) &&
+			(client.m_Ip.GetPort() == m_Ip.GetPort()) &&
 			(client.m_ReflectorModule == m_ReflectorModule));
 }
 

--- a/src/cclients.cpp
+++ b/src/cclients.cpp
@@ -122,7 +122,8 @@ std::shared_ptr<CClient> CClients::FindClient(const CIp &Ip)
 	// find client
 	for ( auto it=begin(); it!=end(); it++ )
 	{
-		if ( (*it)->GetIp() == Ip )
+                // check the port too to allow multiple clients from the same ip
+		if ( ((*it)->GetIp() == Ip) && ((*it)->GetIp().GetPort() == Ip.GetPort()) )
 		{
 			return *it;
 		}


### PR DESCRIPTION
I believe this corrects the odd behaviour when you have multiple connections from the same IP (for us this is cross connect links) 

I've been running this fix on 201 for a few days now and it seems to work the same as upstream now.